### PR TITLE
docs: 公开项目文档与注释规范（v0.0.4）

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,58 @@
-﻿# [Signature](https://github.com/VitaTsui/signature.git)
+# @hsu-react/signature
 
-## 前言
+[![npm version](https://img.shields.io/npm/v/@hsu-react/signature.svg)](https://www.npmjs.com/package/@hsu-react/signature)
+[![license](https://img.shields.io/npm/l/@hsu-react/signature.svg)](./LICENSE)
 
-`Signature` 一个适用于 React 的签字板
+React 手写签名板组件：全屏签字，支持横 / 竖屏，确认后导出签名图片（dataURL 与 Blob）。
 
 ## 效果
 
-![竖屏](/image/竖屏.png)
-![横屏](/image/横屏.png)
+![竖屏](./image/竖屏.png)
+![横屏](./image/横屏.png)
 
 ## 安装
 
-```sh
-npm install --save @hsu-react/signature
+```bash
+npm install @hsu-react/signature
 # 或
 yarn add @hsu-react/signature
 ```
 
 ## 使用
 
-```react
+```tsx
+import React, { useState } from "react";
 import Signature from "@hsu-react/signature";
 
-const App:React.FC = () => {
+const App: React.FC = () => {
+  const [visible, setVisible] = useState(false);
+
   return (
-    <Signature />
+    <Signature
+      visible={visible}
+      onConfirm={(src, blob) => {
+        // src 为签名图片的 dataURL，blob 为对应的 Blob
+        setVisible(false);
+      }}
+      onCancel={() => setVisible(false)}
+    />
   );
-}
+};
 ```
 
-## 参数
+## API
 
-| 参数       | 说明         | 类型                                      | 默认值 |
-| ---------- | ------------ | ----------------------------------------- | ------ |
-| onConfirm  | 点击确认回调 | (src: string, blob: Blob \| null) => void | -      |
-| onCancel   | 点击取消回调 | () => void                                | -      |
-| horizontal | 是否横屏     | boolean                                   | false  |
-| visible    | 是否显示     | boolean                                   | false  |
+| 参数       | 说明                                                | 类型                                      | 默认值  |
+| ---------- | --------------------------------------------------- | ----------------------------------------- | ------- |
+| visible    | 是否显示签名板                                      | `boolean`                                 | `false` |
+| horizontal | 是否横屏书写                                        | `boolean`                                 | `false` |
+| onConfirm  | 点击确认的回调，返回签名图片的 dataURL 与 Blob      | `(src: string, blob: Blob \| null) => void` | -       |
+| onCancel   | 点击取消的回调                                      | `() => void`                              | -       |
+
+## 贡献
+
+日常开发在 `develop` 分支进行（feature 分支合入 `develop`），`main` 只接受来自 `develop` 的 PR；合入 `main` 后按 `package.json` 版本自动打 tag 并发布 npm。PR 标题遵循 [Conventional Commits](https://www.conventionalcommits.org/)。
+
+## License
+
+[MIT](./LICENSE) © VitaHsu

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hsu-react/signature",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "React 手写签名板组件，支持横竖屏与图片导出",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,20 @@
 {
   "name": "@hsu-react/signature",
   "version": "0.0.3",
-  "description": "A React Signature Component",
+  "description": "React 手写签名板组件，支持横竖屏与图片导出",
+  "keywords": [
+    "react",
+    "signature",
+    "signature-pad",
+    "canvas",
+    "handwriting"
+  ],
   "license": "MIT",
-  "repository": "git@github.com:VitaTsui/signature.git",
+  "homepage": "https://github.com/VitaTsui/signature#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/VitaTsui/signature.git"
+  },
   "author": "VitaHsu <vitahsu7@gmail.com>",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,12 +3,20 @@ import ReactDOM from 'react-dom'
 import './index.scss'
 
 export interface SProps {
+  /** Confirm callback; `src` is the signature image dataURL, `blob` is the matching PNG Blob */
   onConfirm?: (src: string, blob: Blob | null) => void
+  /** Cancel callback */
   onCancel?: () => void
+  /** Write in landscape mode (canvas rotated 90°), defaults to false */
   horizontal?: boolean
+  /** Whether the signature pad is visible, defaults to false */
   visible?: boolean
 }
 
+/**
+ * Fullscreen handwritten signature pad. Rendered into document.body via a Portal,
+ * supports portrait / landscape writing, and exports the signature image through onConfirm.
+ */
 const Signature: React.FC<SProps> = (props) => {
   const { onConfirm, horizontal, visible, onCancel } = props
   const ref = useRef<HTMLDivElement>(null)
@@ -50,7 +58,7 @@ const Signature: React.FC<SProps> = (props) => {
         canvas.addEventListener('touchstart', function (event: TouchEvent) {
           setDraw(true)
 
-          event.preventDefault() // 阻止在canvas画布上签名的时候页面跟着滚动
+          event.preventDefault() // Prevent the page from scrolling while signing on the canvas
 
           const touches = event.touches[0]
           beginX = touches.clientX - signature.offsetLeft
@@ -63,7 +71,7 @@ const Signature: React.FC<SProps> = (props) => {
         })
 
         canvas.addEventListener('touchmove', function (event: TouchEvent) {
-          event.preventDefault() // 阻止在canvas画布上签名的时候页面跟着滚动
+          event.preventDefault() // Prevent the page from scrolling while signing on the canvas
 
           const touches = event.touches[0]
           let stopX = touches.clientX - signature.offsetLeft
@@ -75,7 +83,7 @@ const Signature: React.FC<SProps> = (props) => {
           }
 
           writing(beginX, beginY, stopX, stopY, ctx)
-          beginX = stopX // 这一步很关键，需要不断更新起点，否则画出来的是射线簇
+          beginX = stopX // Crucial: keep updating the start point, otherwise strokes fan out as rays from one origin
           beginY = stopY
 
           setDrawed(true)
@@ -97,15 +105,16 @@ const Signature: React.FC<SProps> = (props) => {
     })
   }, [canvas])
 
+  // Draw one stroke segment from (beginX, beginY) to (stopX, stopY)
   const writing = (beginX: number, beginY: number, stopX: number, stopY: number, ctx: CanvasRenderingContext2D) => {
-    ctx.beginPath() // 开启一条新路径
-    ctx.globalAlpha = 1 // 设置图片的透明度
-    ctx.lineWidth = 3 // 设置线宽
-    ctx.strokeStyle = 'black' // 设置路径颜色
-    ctx.moveTo(beginX, beginY) // 从(beginX, beginY)这个坐标点开始画图
-    ctx.lineTo(stopX, stopY) // 定义从(beginX, beginY)到(stopX, stopY)的线条（该方法不会创建线条）
-    ctx.closePath() // 创建该条路径
-    ctx.stroke() // 实际地绘制出通过 moveTo() 和 lineTo() 方法定义的路径。默认颜色是黑色。
+    ctx.beginPath()
+    ctx.globalAlpha = 1
+    ctx.lineWidth = 3
+    ctx.strokeStyle = 'black'
+    ctx.moveTo(beginX, beginY)
+    ctx.lineTo(stopX, stopY)
+    ctx.closePath()
+    ctx.stroke()
   }
 
   const confirm = () => {


### PR DESCRIPTION
## 内容

- README 统一结构：徽章 / 安装 / 使用示例 / API / 贡献 / License
- package.json 完善 description，补 keywords / homepage，repository 改为 https 形式
- 组件与 props 补英文 JSDoc，清理逐行复述式注释并统一为英文（修正 closePath/globalAlpha 两处错误描述）
- 版本 0.0.4

## 验证

- `yarn build` 通过；改动经去注释比对确认零代码变更

🤖 Generated with [Claude Code](https://claude.com/claude-code)